### PR TITLE
Make groupId pluggable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ $ ant -f ./make/langtools/netbeans/nb-javac zip-nb-javac-sources
 
 4. Run
    ```
-   ant -f ./make/langtools/netbeans/nb-javac publish-to-ossrh-snapshots
+   ant -f ./make/langtools/netbeans/nb-javac publish-to-ossrh-snapshots -Dmaven.groupId=your.grp.id
    ```
    to publish snapshot artifacts (https://oss.sonatype.org/content/repositories/snapshots/)
 
 5. Run
    ```
-   ant -f ./make/langtools/netbeans/nb-javac publish-to-maven-central
+   ant -f ./make/langtools/netbeans/nb-javac publish-to-maven-central -Dmaven.groupId=your.grp.id -Dmaven.version=15.0.3
    ```
    to stage the release, which will get promoted to maven central, after it has
    been manually released.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ ant -f ./make/langtools/netbeans/nb-javac zip-nb-javac-sources
 
 5. Run
    ```
-   ant -f ./make/langtools/netbeans/nb-javac publish-to-maven-central -Dmaven.groupId=your.grp.id -Dmaven.version=15.0.3
+   ant -f ./make/langtools/netbeans/nb-javac publish-to-maven-central -Dmaven.groupId=your.grp.id
    ```
    to stage the release, which will get promoted to maven central, after it has
    been manually released.

--- a/make/langtools/netbeans/nb-javac/build.xml
+++ b/make/langtools/netbeans/nb-javac/build.xml
@@ -161,9 +161,16 @@
     <property name="maven-staging-repository-id" value="oss.sonatype.org" />
     <property name="maven-staging-repository-url" value="https://oss.sonatype.org/service/local/staging/deploy/maven2/" />
 
-    <target name="publish-to-ossrh-snapshots"
-            description="Build nb-javac and publish to Snapshot Repository of OSSRH"
-            depends="clean,jar,zip-nb-javac-sources">
+    <target name="-prepare-maven-version" depends="clean,jar">
+        <property name="maven.version" value="${nb-javac-ver}"/>
+    </target>
+    <target name="-prepare-maven-snapshot-version" depends="clean,jar">
+        <property name="maven.version" value="${nb-javac-ver}-SNAPSHOT"/>
+    </target>
+
+    <target name="-prepare-maven" depends="clean,jar,zip-nb-javac-sources">
+        <fail message="Version must be specified!" unless="maven.version"></fail>
+        <fail message="Specify -Dmaven.groupId=..." unless="maven.groupId"></fail>
 
         <zip basedir="../../../../" destfile="dist/nb-javac-${nb-javac-ver}-doc.zip">
             <include name="README.md"/>
@@ -175,8 +182,17 @@
         <copy file="pom-nb-javac.xml" todir="build" />
 
         <replaceregexp match="(&lt;version&gt;).*(&lt;/version&gt;)"
-                       replace="\1${nb-javac-ver}-SNAPSHOT\2"
+                       replace="\1${maven.version}\2"
                        file="build/pom-nb-javac.xml"/>
+
+        <replaceregexp match="(&lt;groupId&gt;).*(&lt;/groupId&gt;)"
+                       replace="\1${maven.groupId}\2"
+                       file="build/pom-nb-javac.xml"/>
+    </target>
+
+    <target name="publish-to-ossrh-snapshots"
+            description="Build nb-javac and publish to Snapshot Repository of OSSRH"
+            depends="-prepare-maven-snapshot-version,-prepare-maven">
 
         <exec executable="mvn" output="build/maven-publish.log" failonerror="true">
             <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file"/>
@@ -192,20 +208,7 @@
 
     <target name="publish-to-maven-central" 
             description="Build nb-javac and stage for maven central"
-            depends="clean,jar,zip-nb-javac-sources">
-
-        <zip basedir="../../../../" destfile="dist/nb-javac-${nb-javac-ver}-doc.zip">
-            <include name="README.md"/>
-            <include name="SECURITY.md"/>
-            <include name="LICENSE.txt"/>
-            <include name="CONTRIBUTING.md"/>
-        </zip>
-
-        <copy file="pom-nb-javac.xml" todir="build" />
-
-        <replaceregexp match="(&lt;version&gt;).*(&lt;/version&gt;)"
-                       replace="\1${nb-javac-ver}\2"
-                       file="build/pom-nb-javac.xml"/>
+            depends="-prepare-maven-version,-prepare-maven">
 
         <exec executable="mvn" output="build/maven-publish.log" failonerror="true">
             <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.4:sign-and-deploy-file"/>

--- a/make/langtools/netbeans/nb-javac/pom-nb-javac.xml
+++ b/make/langtools/netbeans/nb-javac/pom-nb-javac.xml
@@ -4,7 +4,7 @@
   http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>eu.doppel-helix.com.github.oracle.nb-javac</groupId>
+  <groupId>TEMPLATE</groupId>
   <artifactId>nb-javac</artifactId>
   <version>TEMPLATE</version>
   <packaging>jar</packaging>


### PR DESCRIPTION
In addition to [PR #2](https://github.com/oracle/nb-javac/pull/2) I suggest to make `maven.groupId` pluggable to allow any 3rd party to publish `nb-javac` easily. When at it, I also introduced optional `maven.version` property. As such one can fully control publishing with:

```bash
ant -f ./make/langtools/netbeans/nb-javac publish-to-maven-central -Dmaven.groupId=your.grp.id -Dmaven.version=15.0.3
```